### PR TITLE
Changed order of build command in Makefile to fix compilation errors in some gcc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(BUILD)/%.o: $(SRC)/%.c
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 $(TARGET): $(SRC)/main.c $(BUILD) $(OBJS)
-	$(CC) -o $(TARGET) $(CFLAGS) $(LIBS) $(OBJS) $<
+	$(CC) -o $(TARGET) $(CFLAGS) $< $(LIBS) $(OBJS)
 
 clean:
 	rm -rf $(BUILD) $(TARGET)


### PR DESCRIPTION
Was having trouble building on Ubuntu, it came down to ordering in the last build command. Tested this and it works on both Ubuntu 18.04 with gcc version 7.4.0 and Fedora 31 with gcc 9.2.1.