### PR TITLE
Ubuntu docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ dnf install gtk3-devel gstreamer1-devel gstreamer1-plugins-base-devel libcurl-de
 
 To build MonStream, run `make` in the repository root.
 
+Building on Ubuntu with the repo stored in /opt/ can be accomplished with the following:
+
+```Bash
+sudo apt install git gcc make libcurl4-openssl-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+cd /opt/
+git clone https://github.com/mnit-rtmc/monstream.git
+pushd monstream
+make
+popd
+sudo ln -s /opt/monstream/monstream /usr/bin/monstream
+```
+
+Tested on Ubuntu 20.04 ARM. Make sure to change permissions appropriately.
+
 ### Configuration
 
 The `/var/lib/monstream` directory is used for caching data.  Create it and give

--- a/README.md
+++ b/README.md
@@ -13,27 +13,32 @@ MonStream has a few build dependencies:
 * gstreamer1-plugins-base
 * libcurl
 
+### Fedora
+
 The `devel` packages for these can be installed on Fedora with:
 
-```
+```bash
 dnf install gtk3-devel gstreamer1-devel gstreamer1-plugins-base-devel libcurl-devel
 ```
 
 To build MonStream, run `make` in the repository root.
 
+### Ubuntu
+
 Building on Ubuntu with the repo stored in /opt/ can be accomplished with the following:
 
-```Bash
-sudo apt install git gcc make libcurl4-openssl-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+```bash
+sudo apt install git gcc make libcurl4-openssl-dev libgtk-3-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav 
 cd /opt/
 git clone https://github.com/mnit-rtmc/monstream.git
 pushd monstream
 make
 popd
 sudo ln -s /opt/monstream/monstream /usr/bin/monstream
+sudo mkdir /var/lib/monstream
 ```
 
-Tested on Ubuntu 20.04 ARM. Make sure to change permissions appropriately.
+Tested on Ubuntu 20.04 with Desktop ARM64 and AMD64. Make sure to change permissions appropriately so that the user running monstream can modify the /var/lib/monstream directory. Plays well with Wayland and X11 out of the box.
 
 ### Configuration
 
@@ -47,3 +52,5 @@ These files are managed automatically and are not meant to be edited:
 * `monitor.0` .. `monitor.n` - Parameters for each monitor
 * `play.0` .. `play.n` - Stream information for each monitor
 * `cache` - Directory containing SDP files for known streams
+
+see doc/protocol.md for more information on constructing messages that are used to manage monstream.

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -41,7 +41,7 @@ configuration is completed.
 2. Monitor index
 3. Camera ID
 4. Stream request URI
-5. Encoding: `MPEG2`, `MPEG4`, `H264`, `PNG`
+5. Encoding: `MPEG2`, `MPEG4`, `H264`, `PNG`, `MJPEG`
 6. Title: ASCII text description
 7. Latency (0-2000 ms)
 


### PR DESCRIPTION
Update documentation to include build process for Ubuntu.
* Separate out to sub-heading section in installation for Ubuntu and Fedora
* Include basic bash example for installing dependencies, cloning repo, building, and linking to /usr/bin/monstream
* Add a pointer to docs in README for message formats.
*  Include MJPEG in supported formats (Found in stream.c  Verified with Purdue camera running mjpeg at http://webcam01.ecn.purdue.edu/mjpg/video.mjpg) 